### PR TITLE
Fix use of URI.encode - DEV-1113

### DIFF
--- a/lib/eway_rapid/message/process/refund_process.rb
+++ b/lib/eway_rapid/message/process/refund_process.rb
@@ -17,7 +17,7 @@ module EwayRapid
         # @return [String]
         def self.send_request(url, api_key, password, version, request)
           url = url + '/' + request.refund.original_transaction_id.to_s + '/' + Constants::REFUND_SUB_PATH_METHOD
-          url = URI.encode(url)
+          url = URI::Parser.new.escape(url)
           RefundMsgProcess.new.do_post(url, api_key, password, version, request)
         end
 

--- a/lib/eway_rapid/rapid_client.rb
+++ b/lib/eway_rapid/rapid_client.rb
@@ -268,7 +268,7 @@ module EwayRapid
       end
       begin
         url = @web_url + Constants::DIRECT_CUSTOMER_SEARCH_METHOD + Constants::JSON_SUFFIX
-        url = URI.encode(url)
+        url = URI::Parser.new.escape(url)
 
         request = Message::CustomerProcess::QueryCustomerMsgProcess.create_request(token_customer_id.to_s)
         response = Message::CustomerProcess::QueryCustomerMsgProcess.send_request(url, @api_key, @password, @version, request)
@@ -341,7 +341,7 @@ module EwayRapid
         else
           url = @web_url + request_path + '/' + request
         end
-        url = URI.encode(url)
+        url = URI::Parser.new.escape(url)
 
         response = Message::TransactionProcess::TransQueryMsgProcess.process_post_msg(url, @api_key, @password, @version)
         Message::TransactionProcess::TransQueryMsgProcess.make_result(response)

--- a/lib/eway_rapid/version.rb
+++ b/lib/eway_rapid/version.rb
@@ -1,3 +1,3 @@
 module EwayRapid
-  VERSION = '2.0.1'
+  VERSION = '2.0.2'
 end


### PR DESCRIPTION
`URI.encode` is deprecated in Ruby 2.7 and disappears in Ruby 3. There is a perfect equivalent in Ruby 3, though, that also works in Ruby 2.
